### PR TITLE
Automatically load task tasks in rails

### DIFF
--- a/lib/pansophy.rb
+++ b/lib/pansophy.rb
@@ -40,3 +40,4 @@ require 'pansophy/remote'
 require 'pansophy/local'
 require 'pansophy/synchronizer'
 require 'pansophy/config_synchronizer'
+require 'pansophy/railtie' if defined?(Rails)

--- a/lib/pansophy/railtie.rb
+++ b/lib/pansophy/railtie.rb
@@ -1,0 +1,7 @@
+module Pansophy
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load 'pansophy/tasks.rb'
+    end
+  end
+end


### PR DESCRIPTION
Add railtie so apps like on-deck and others don't need to require task manually all the time.

This is a standard practice amongst gems that want to integrate nicely with rails and introduces no new dependencies as it only fires if Rails is defined.
