### PR TITLE
Tt 1616 jruby ssl error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Use coverage kit to enforce maximum coverage
+- [TT-1616] Reset Excon cipher list to the default which fixes connection issue from JRuby
 
 ## [0.5.2]
 ### Fixed

--- a/lib/pansophy/connection.rb
+++ b/lib/pansophy/connection.rb
@@ -1,6 +1,7 @@
 module Pansophy
   module Connection
     def self.aws
+      Excon.defaults[:ciphers] = 'DEFAULT'
       Fog::Storage.new(
         provider:              'AWS',
         aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],


### PR DESCRIPTION
**Why**  
Econ by default uses a cipher list that is incompatible with JRuby.

**Test**
Run pansophy from jruby
Run panshophy from ruby