### PR TITLE
EE-34 pansophy file attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Change Log
 
 ## [Unreleased]
-
-## [0.5.6]
 ### Changed
 - Allow specifying file attributes when creating files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.5.6]
+### Changed
+- Allow specifying file attributes when creating files
+
 ## [0.5.5]
 ### Fixed
 - Remove overly strict dependencies

--- a/lib/pansophy/remote/create_file.rb
+++ b/lib/pansophy/remote/create_file.rb
@@ -1,3 +1,5 @@
+require 'facets/hash/slice'
+
 module Pansophy
   module Remote
     class CreateFile
@@ -29,7 +31,7 @@ module Pansophy
 
       def call(options = {})
         prevent_overwrite! unless options[:overwrite]
-        file_attributes = options.delete_if { |k,v| !ALLOWED_ATTRS.include?(k) }
+        file_attributes = options.slice(*ALLOWED_ATTRS)
         directory.files.create(file_attributes.merge(key: @pathname.to_s, body: @body.dup))
       end
 

--- a/lib/pansophy/remote/create_file.rb
+++ b/lib/pansophy/remote/create_file.rb
@@ -3,6 +3,24 @@ module Pansophy
     class CreateFile
       include Adamantium::Flat
 
+      ALLOWED_ATTRS = %i[
+        cache_control
+        content_disposition
+        content_encoding
+        content_length
+        content_md5
+        content_type
+        etag
+        expires
+        last_modified
+        metadata
+        owner
+        storage_class
+        encryption
+        encryption_key
+        version
+      ].freeze
+
       def initialize(bucket, path, body)
         @bucket   = bucket
         @pathname = Pathname.new(path)
@@ -11,7 +29,8 @@ module Pansophy
 
       def call(options = {})
         prevent_overwrite! unless options[:overwrite]
-        directory.files.create(key: @pathname.to_s, body: @body.dup)
+        params = options.slice(*ALLOWED_ATTRS).merge(key: @pathname.to_s, body: @body.dup)
+        directory.files.create(params)
       end
 
       private

--- a/lib/pansophy/remote/create_file.rb
+++ b/lib/pansophy/remote/create_file.rb
@@ -29,8 +29,8 @@ module Pansophy
 
       def call(options = {})
         prevent_overwrite! unless options[:overwrite]
-        params = options.slice(*ALLOWED_ATTRS).merge(key: @pathname.to_s, body: @body.dup)
-        directory.files.create(params)
+        file_attributes = options.delete_if { |k,v| !ALLOWED_ATTRS.include?(k) }
+        directory.files.create(file_attributes.merge(key: @pathname.to_s, body: @body.dup))
       end
 
       private


### PR DESCRIPTION
### Why
This allows us to specify all allowed attributes when creating files in the s3 bucket, useful for setting things like cache_control.
