### PR TITLE
Upgrade the AWS Fog dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.0.0] Unreleased
+### Added
+- [DO-228] Upgrade the AWS Fog dependency
+
 ## [0.6.0]
 ### Added
 - [DO-90] Support using EC2 profile when fetching configuration files

--- a/lib/pansophy/version.rb
+++ b/lib/pansophy/version.rb
@@ -1,3 +1,3 @@
 module Pansophy
-  VERSION = '0.6.0'
+  VERSION = '1.0.0'
 end

--- a/pansophy.gemspec
+++ b/pansophy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency 'fog-aws', '~> 0.13'
+  spec.add_dependency 'fog-aws', '~> 2.0'
   spec.add_dependency 'mime-types'
   spec.add_dependency 'anima'
   spec.add_dependency 'adamantium'


### PR DESCRIPTION
# Why?

We need to upgrade the dependency so that this project is compatible with the other newer projects.

# Testing

Tested in our AWS stack.